### PR TITLE
Add autosize type 'fit-x'

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pretest": "rm -rf build && mkdir build && rollup -g vega-dataflow:vega,vega-scenegraph:vega,vega-util:vega -f umd -n vega.transforms -o build/vega-view-transforms.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src test",
     "prepublish": "npm run build",
+    "prepare": "npm run build",
     "postpublish": "git push && git push --tags && zip -j build/vega-view-transforms.zip -- LICENSE README.md build/vega-view-transforms.js build/vega-view-transforms.min.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "pretest": "rm -rf build && mkdir build && rollup -g vega-dataflow:vega,vega-scenegraph:vega,vega-util:vega -f umd -n vega.transforms -o build/vega-view-transforms.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src test",
     "prepublish": "npm run build",
-    "prepare": "npm run build",
     "postpublish": "git push && git push --tags && zip -j build/vega-view-transforms.zip -- LICENSE README.md build/vega-view-transforms.js build/vega-view-transforms.min.js"
   },
   "dependencies": {

--- a/src/ViewLayout.js
+++ b/src/ViewLayout.js
@@ -5,6 +5,7 @@ import {Bounds, boundStroke} from 'vega-scenegraph';
 import {inherits} from 'vega-util';
 
 var Fit = 'fit',
+    FitX = 'fit-x',
     Pad = 'pad',
     None = 'none',
     Padding = 'padding';
@@ -400,6 +401,12 @@ function layoutSize(view, group, viewBounds, _) {
   else if (type === Fit) {
     width = Math.max(0, viewWidth - left - right);
     height = Math.max(0, viewHeight - top - bottom);
+  }
+  
+  else if (type === FitX) {
+    width = Math.max(0, viewWidth - left - right);
+    height = height + top + bottom;
+    viewHeight = height;
   }
 
   else if (type === Pad) {


### PR DESCRIPTION
For the embedding on websites, it would be nice if charts could be defined with a fixed width and a flexible height. The graph's width should fit exactly (and behave like the autosize type `fit`) but the height should be calculated like autosize type `pad` (with no `height` set). While it's not possible to realize this combined setup, I propose a new autosize type called `fit-x`. Choosing this autosize type allows to make responsive charts with an exact width.